### PR TITLE
Add cross-platform mkdir wrapper for Windows and Linux compatibility

### DIFF
--- a/PAKerUtility/PAK.c
+++ b/PAKerUtility/PAK.c
@@ -7,8 +7,11 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#define MKDIR(path, mode) mkdir(path, mode)
 #elif defined(_WIN32) || defined(WIN32)
 #include <direct.h>
+#define MKDIR(path, mode) mkdir(path)
+
 #endif
 
 #include "PAK.h"
@@ -78,11 +81,11 @@ int ExtractFilePAKFile(FILE *infp, unsigned int index, struct PAKFileData* PAKFi
 				{
 					if ((p_name[iii] == '/') || (p_name[iii] == '\\')) {
 						p_name[iii] = '\0';
-						mkdir(PAKFileData->FileEntries[index].filepath, 775);
+						MKDIR(PAKFileData->FileEntries[index].filepath, 775);
 						p_name[iii] = slash;
 					}
 				}
-				mkdir(PAKFileData->FileEntries[index].filepath, 775);
+				MKDIR(PAKFileData->FileEntries[index].filepath, 775);
 				p_name[ii] = slash;
 				break;
 			}
@@ -196,7 +199,7 @@ int DumpPAKFile(const char *filename){
 	strcat(FOLDER, filename);
 	if((infp=fopen(filename, "rb"))!=NULL){
 		if((result=LoadPAKFile(infp, &PAKFileData))==0){
-			mkdir(FOLDER, 775);
+			MKDIR(FOLDER, 775);
 			chdir(FOLDER);
 
 			for(i=0,crc_f=0; i<PAKFileData.Header.num_entries; i++){

--- a/PAKerUtility/PAK.c
+++ b/PAKerUtility/PAK.c
@@ -5,6 +5,8 @@
 
 #ifdef __unix__
 #include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #elif defined(_WIN32) || defined(WIN32)
 #include <direct.h>
 #endif
@@ -76,11 +78,11 @@ int ExtractFilePAKFile(FILE *infp, unsigned int index, struct PAKFileData* PAKFi
 				{
 					if ((p_name[iii] == '/') || (p_name[iii] == '\\')) {
 						p_name[iii] = '\0';
-						mkdir(PAKFileData->FileEntries[index].filepath);
+						mkdir(PAKFileData->FileEntries[index].filepath, 775);
 						p_name[iii] = slash;
 					}
 				}
-				mkdir(PAKFileData->FileEntries[index].filepath);
+				mkdir(PAKFileData->FileEntries[index].filepath, 775);
 				p_name[ii] = slash;
 				break;
 			}
@@ -194,7 +196,7 @@ int DumpPAKFile(const char *filename){
 	strcat(FOLDER, filename);
 	if((infp=fopen(filename, "rb"))!=NULL){
 		if((result=LoadPAKFile(infp, &PAKFileData))==0){
-			mkdir(FOLDER);
+			mkdir(FOLDER, 775);
 			chdir(FOLDER);
 
 			for(i=0,crc_f=0; i<PAKFileData.Header.num_entries; i++){

--- a/PAKerUtility/main.c
+++ b/PAKerUtility/main.c
@@ -5,6 +5,8 @@
 
 #ifdef __unix__
 #include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #elif defined(_WIN32) || defined(WIN32)
 #include <direct.h>
 #endif


### PR DESCRIPTION
On Linux/Unix, mkdir requires two arguments (path and mode), while on Windows it only takes one.
This caused build issues when compiling the project on different platforms.

This PR introduces a portable MKDIR macro:

On Windows, it maps to mkdir(path)

On Linux/Unix, it maps to mkdir(path, mode)

All existing code can now call MKDIR(path, mode) safely, ensuring consistent behavior across platforms.